### PR TITLE
fix(scaffold): make generated projects pass tests out of the box

### DIFF
--- a/act_operator/act_operator/scaffold/{{ cookiecutter.act_slug }}/.pre-commit-config.yaml
+++ b/act_operator/act_operator/scaffold/{{ cookiecutter.act_slug }}/.pre-commit-config.yaml
@@ -5,14 +5,14 @@ repos:
     rev: 0.9.2
     hooks:
       - id: uv-lock
-        # 의존성 락 파일 동기화
+        # Keep the dependency lock file in sync
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.12.0
     hooks:
       - id: ruff-check
-        # 코드 품질 점검 및 임포트 정리
+        # Lint and tidy imports
         types_or: [python, pyi]
         args: [--fix]
       - id: ruff-format
-        # 코드 포맷팅
+        # Format code
         types_or: [python, pyi]

--- a/act_operator/act_operator/scaffold/{{ cookiecutter.act_slug }}/casts/{{ cookiecutter.cast_snake }}/modules/agents.py
+++ b/act_operator/act_operator/scaffold/{{ cookiecutter.act_slug }}/casts/{{ cookiecutter.cast_snake }}/modules/agents.py
@@ -1,4 +1,4 @@
-"""[Optional] Construct agents required by the Sample Cast graph.
+"""[Optional] Construct agents required by the {{ cookiecutter.cast_name }} graph.
 
 Guidelines:
     - Create agents using the `langchain.agents` module.

--- a/act_operator/act_operator/scaffold/{{ cookiecutter.act_slug }}/casts/{{ cookiecutter.cast_snake }}/modules/middlewares.py
+++ b/act_operator/act_operator/scaffold/{{ cookiecutter.act_slug }}/casts/{{ cookiecutter.cast_snake }}/modules/middlewares.py
@@ -1,4 +1,4 @@
-"""[Optional] Middleware Classes for Sam graphs.
+"""[Optional] Middleware Classes for the {{ cookiecutter.cast_name }} graph.
 
 Guidelines:
     - Use built-in middleware (e.g., PIIMiddleware) for common use cases.

--- a/act_operator/act_operator/scaffold/{{ cookiecutter.act_slug }}/casts/{{ cookiecutter.cast_snake }}/modules/nodes.py
+++ b/act_operator/act_operator/scaffold/{{ cookiecutter.act_slug }}/casts/{{ cookiecutter.cast_snake }}/modules/nodes.py
@@ -37,9 +37,15 @@ class SampleNode(BaseNode):
             state: Current graph state.
 
         Returns:
-            dict: State updates (must be a dict)
+            dict: State updates (must be a dict). Writes both ``result``
+            (exposed by OutputState) and ``messages`` (accumulated via
+            MessagesState's ``add_messages`` reducer).
         """
-        return {"messages": [AIMessage(content="Welcome to the Act! by Sync Node")]}
+        welcome = "Welcome to the Act!"
+        return {
+            "result": welcome,
+            "messages": [AIMessage(content=f"{welcome} by Sync Node")],
+        }
 
 
 class AsyncSampleNode(AsyncBaseNode):
@@ -60,6 +66,12 @@ class AsyncSampleNode(AsyncBaseNode):
             state: Current graph state.
 
         Returns:
-            dict: State updates (must be a dict)
+            dict: State updates (must be a dict). Writes both ``result``
+            (exposed by OutputState) and ``messages`` (accumulated via
+            MessagesState's ``add_messages`` reducer).
         """
-        return {"messages": [AIMessage(content="Welcome to the Act! by Async Node")]}
+        welcome = "Welcome to the Act!"
+        return {
+            "result": welcome,
+            "messages": [AIMessage(content=f"{welcome} by Async Node")],
+        }

--- a/act_operator/act_operator/scaffold/{{ cookiecutter.act_slug }}/casts/{{ cookiecutter.cast_snake }}/modules/state.py
+++ b/act_operator/act_operator/scaffold/{{ cookiecutter.act_slug }}/casts/{{ cookiecutter.cast_snake }}/modules/state.py
@@ -1,4 +1,4 @@
-"""[Required] State definition shared across sam graphs.
+"""[Required] State definition for the {{ cookiecutter.cast_name }} graph.
 
 Guidelines:
     - Create TypedDict classes for input, output, overall state, and any other state you need.

--- a/act_operator/act_operator/scaffold/{{ cookiecutter.act_slug }}/pyproject.toml
+++ b/act_operator/act_operator/scaffold/{{ cookiecutter.act_slug }}/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
 [dependency-groups]
 test = [
     "pytest",
+    "pytest-asyncio",
     "langgraph-cli[inmem]",
 ]
 lint = [
@@ -27,10 +28,15 @@ dev = [
 [tool.pyright]
 include = ["casts", "tests"]
 exclude = [
-    "**/__pycache__/*", 
-    ".venv", 
+    "**/__pycache__/*",
+    ".venv",
     "**/.venv"
 ]
+
+[tool.pytest.ini_options]
+pythonpath = ["."]
+testpaths = ["tests"]
+asyncio_mode = "auto"
 
 [tool.uv.workspace]
 members = ["casts/*"]

--- a/act_operator/act_operator/scaffold/{{ cookiecutter.act_slug }}/tests/cast_tests/{{ cookiecutter.cast_snake }}_test.py
+++ b/act_operator/act_operator/scaffold/{{ cookiecutter.act_slug }}/tests/cast_tests/{{ cookiecutter.cast_snake }}_test.py
@@ -11,9 +11,9 @@ from casts.{{ cookiecutter.cast_snake }}.graph import {{ cookiecutter.cast_snake
 def test_graph_produces_message() -> None:
     graph = {{ cookiecutter.cast_snake }}_graph()
 
-    # 최소 상태로 그래프 실행 — OutputState filter가 적용되어 ``result`` 키만 노출됨
+    # Invoke with minimal state — OutputState filter exposes only the ``result`` key.
     result = graph.invoke({"query": "I'm joining Act"})
 
-    # SampleNode가 result 키를 생성하는지 확인
+    # Verify SampleNode populated ``result``.
     assert "result" in result
     assert result["result"] == "Welcome to the Act!"

--- a/act_operator/act_operator/scaffold/{{ cookiecutter.act_slug }}/tests/cast_tests/{{ cookiecutter.cast_snake }}_test.py
+++ b/act_operator/act_operator/scaffold/{{ cookiecutter.act_slug }}/tests/cast_tests/{{ cookiecutter.cast_snake }}_test.py
@@ -11,9 +11,9 @@ from casts.{{ cookiecutter.cast_snake }}.graph import {{ cookiecutter.cast_snake
 def test_graph_produces_message() -> None:
     graph = {{ cookiecutter.cast_snake }}_graph()
 
-    # 최소 상태로 그래프 실행
+    # 최소 상태로 그래프 실행 — OutputState filter가 적용되어 ``result`` 키만 노출됨
     result = graph.invoke({"query": "I'm joining Act"})
 
-    # SampleNode가 message 키를 생성하는지 확인
-    assert "messages" in result
-    assert result["messages"] == "Welcome to the Act!"
+    # SampleNode가 result 키를 생성하는지 확인
+    assert "result" in result
+    assert result["result"] == "Welcome to the Act!"

--- a/act_operator/act_operator/scaffold/{{ cookiecutter.act_slug }}/tests/node_tests/test_node.py
+++ b/act_operator/act_operator/scaffold/{{ cookiecutter.act_slug }}/tests/node_tests/test_node.py
@@ -1,4 +1,4 @@
-"""Test the nodes for the Sam graph.
+"""Test the nodes for the {{ cookiecutter.cast_name }} graph.
 
 Official document URL: https://docs.langchain.com/oss/python/langgraph/test"""
 
@@ -10,10 +10,16 @@ from casts.{{ cookiecutter.cast_snake }}.modules.nodes import AsyncSampleNode, S
 def test_base_node_calls_execute() -> None:
     node = SampleNode()
     result = node.execute({"query": "I'm joining Act"})
-    assert result == {"message": "Welcome to the Act!"}
+
+    assert result["result"] == "Welcome to the Act!"
+    assert len(result["messages"]) == 1
+    assert result["messages"][0].content == "Welcome to the Act! by Sync Node"
 
 
 async def test_async_base_node_calls_execute() -> None:
     node = AsyncSampleNode()
     result = await node.execute({"query": "I'm joining Act"})
-    assert result == {"message": "Welcome to the Act!"}
+
+    assert result["result"] == "Welcome to the Act!"
+    assert len(result["messages"]) == 1
+    assert result["messages"][0].content == "Welcome to the Act! by Async Node"


### PR DESCRIPTION
## 🚀 PR Type

- [x] **🎯 Ready for Review** — verified by regenerating `fa` and running `uv run pytest` + `uv run ruff check .`

---

## 📝 Summary

`act new` + `act cast`로 생성된 새 프로젝트가 즉시 `uv run pytest`를 통과하지 못하는 문제 6건 수정. 이 PR 적용 후 갓 스캐폴딩된 프로젝트는 추가 수정 없이 **4/4 테스트 통과**.

## 📄 Description

`act_operator/fa`(개발 환경에 생성된 실제 스캐폴드)로 검증 중 다음 결함들을 발견:

### 1. `tests/node_tests/__init.py` 파일명 오타
- 실제: `__init.py` (밑줄 1개)
- 정상: `__init__.py`
- 영향: 엄격한 모듈 탐색 시 Python이 패키지로 인식 못 함

### 2. `pyproject.toml`에 `[tool.pytest.ini_options]` 부재
- pytest가 부모 디렉토리의 pyproject.toml로 올라가 fallback → `casts` 모듈 import 실패
- 검증 시 3개 test file 모두 `ModuleNotFoundError: No module named 'casts'` collection error
- 추가: `pythonpath = ["."]`, `testpaths = ["tests"]`, `asyncio_mode = "auto"`

### 3. `SampleNode` 와 `OutputState` 의미 불일치 → graph.invoke() 항상 None
- `SampleNode`가 `{"messages": [AIMessage(...)]}`만 반환
- `OutputState`는 `result: str`만 선언 → output filter가 `result`만 노출
- 결과: `graph.invoke({"query": "test"})` → **`None`**
- 수정: `SampleNode`가 `result`와 `messages` 둘 다 작성 (다중 키 state update 패턴도 시연)

### 4. 테스트 어설션이 노드 출력과 완전 불일치
- `test_node.py`: `{"message": "..."}` (단수 + str) vs 실제 `{"messages": [AIMessage]}` (복수 + 리스트)
- `{cast_snake}_test.py`: `result["messages"] == "..."` 는 #3 때문에 `None["messages"]` → `TypeError`
- 양쪽 모두 신규 노드 출력 계약에 맞게 재작성

### 5. `pytest-asyncio` 미설치 + asyncio_mode 미설정
- `test_async_base_node_calls_execute`가 `async def`인데 plugin 없어 collection 실패
- `pytest-asyncio` 추가 + `asyncio_mode = "auto"`로 decorator 없이 자동 collection

### 6. "Sam"/"Sample Cast"/"sam graphs" 하드코딩
- `nodes.py`(처음 docstring은 ok), `state.py`, `middlewares.py`, `agents.py`, `tests/node_tests/test_node.py`
- 모두 `{{ cookiecutter.cast_name }}`로 템플릿화

## ✅ Quality Checks

- [x] `uv run ruff check .` passed (`All checks passed!`)
- [x] `uv run pytest -q` passed (`4 passed in 0.66s`)

**검증 절차:**
```bash
rm -rf fa
uv run python -m act_operator new -p . -a "Fa" -c "dmk" -l en
uv run python -m act_operator cast -p ./fa -c "nvsd"
cd fa
uv sync --group test
uv run pytest -v
# tests/cast_tests/dmk_test.py::test_graph_produces_message PASSED  [ 25%]
# tests/cast_tests/nvsd_test.py::test_graph_produces_message PASSED [ 50%]
# tests/node_tests/test_node.py::test_base_node_calls_execute PASSED [ 75%]
# tests/node_tests/test_node.py::test_async_base_node_calls_execute PASSED [100%]
# 4 passed in 0.66s
```

## 💪 Ownership

- [x] **Hand-raise**: 새 프로젝트의 first-run UX에 큰 영향이라 follow-up 관찰

## 💡 Notes

- **사용자 영향**: 이번 fix가 적용된 act-operator 릴리즈를 사용하는 신규 프로젝트만 영향. 기존 프로젝트는 자체 pyproject.toml과 테스트가 이미 작성되어 있어 영향 없음
- **`act upgrade` 고려**: 기존 프로젝트가 `act upgrade`로 동일 fix를 받을 수 있는지 별도 검증 필요
- **별도 PR (#92)**: cast 스킬 5종 마이그레이션(LangChain 1.3 / LangGraph 1.2 / deepagents 0.6) — 이 PR과 독립

🤖 Generated with [Claude Code](https://claude.com/claude-code)