### PR TITLE
chore(ci): bump release.yml actions to Node.js 24 compatible majors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,12 +27,12 @@ jobs:
       tag: ${{ steps.check-version.outputs.tag }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           enable-cache: true
@@ -66,7 +66,7 @@ jobs:
         run: uvx twine check dist/*
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: dist
           path: ${{ env.WORKING_DIRECTORY }}/dist/
@@ -84,7 +84,7 @@ jobs:
       id-token: write  # Required for trusted publishing
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v6
         with:
           name: dist
           path: dist/
@@ -107,11 +107,11 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v6
         with:
           name: dist
           path: dist/
@@ -207,7 +207,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v6
         with:
           name: dist
           path: dist/


### PR DESCRIPTION
## 🚀 PR Type

- [x] **🎯 Ready for Review** — 변경 범위가 workflow YAML의 action 버전 핀만이라 별도 build 없이 자체 검증 가능.

---

## 📝 Summary

GitHub Actions deprecation 경고 해결: `release.yml`의 Node.js 20 기반 action 버전을 Node.js 24 호환 majors로 bump.

## 📄 Description

### 배경

GitHub Actions deprecation 일정:
- **2026-06-02**: Node.js 24 강제 활성화
- **2026-09-16**: Node.js 20 runner에서 완전 제거

워크플로우 실행 시 다음 경고 표시:
```
Node.js 20 actions are deprecated. The following actions are running on Node.js 20:
  actions/checkout@v4, actions/upload-artifact@v4, astral-sh/setup-uv@v5
```

### 진단

레포 내 모든 workflow를 audit한 결과, **`release.yml` 하나만** 이전 majors를 쓰고 있었음. 다른 workflow들(`ruff.yml`, `pytest.yml`, `uv_lock_upgrade.yml`)은 이미 `checkout@v5` + `setup-uv@v7`.

### 변경

| Action | Before | After | 비고 |
|--------|--------|-------|------|
| `actions/checkout` | v4 (×3) | **v5** | Node 24 기본 |
| `astral-sh/setup-uv` | v5 (×1) | **v7** | 다른 workflow와 일관 |
| `actions/upload-artifact` | v4 (×1) | **v6** | v5는 여전히 Node 20 default |
| `actions/download-artifact` | v4 (×3) | **v6** | v5는 여전히 Node 20 default |

### 변경하지 않은 항목

deprecation 경고에 언급되지 않았고 현재 major가 Node 24 호환:
- `amannn/action-semantic-pull-request@v6`
- `softprops/action-gh-release@v2`
- `pypa/gh-action-pypi-publish@release/v1`
- `peter-evans/create-pull-request@v7`

## ✅ Quality Checks

- 코드 변경 없음 (YAML 버전 문자열만)
- ruff/pytest 영향 없음
- 다음 release workflow 실행 시 경고 사라짐 예상

🤖 Generated with [Claude Code](https://claude.com/claude-code)