### PR TITLE
fix(scaffold): use cross-platform venv path in vscode settings

### DIFF
--- a/act_operator/act_operator/scaffold/{{ cookiecutter.act_slug }}/.vscode/settings.json
+++ b/act_operator/act_operator/scaffold/{{ cookiecutter.act_slug }}/.vscode/settings.json
@@ -17,7 +17,7 @@
   "[yaml]": {
     "editor.defaultFormatter": "redhat.vscode-yaml"
   },
-  "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
+  "python.defaultInterpreterPath": "${workspaceFolder}/.venv",
   "python.testing.pytestEnabled": true,
   "python.testing.pytestArgs": [],
   "python.testing.autoTestDiscoverOnSaveEnabled": true,


### PR DESCRIPTION
## Summary
- Drop the OS-specific `bin/python` suffix from `python.defaultInterpreterPath` in the scaffold's `.vscode/settings.json`
- Python extension now auto-resolves the interpreter for both Windows (`Scripts/python.exe`) and Linux/macOS (`bin/python`)

## Test plan
- [ ] Generate a project via `act new` on Linux and confirm VS Code picks up `.venv/bin/python`
- [ ] Generate a project on Windows and confirm VS Code picks up `.venv/Scripts/python.exe`

🤖 Generated with [Claude Code](https://claude.com/claude-code)